### PR TITLE
Made it play nice with 0.11.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.un~
+*.sublime-*
+/node_modules/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL := /bin/bash
 
 test:
-	@node-far test/ -i "test-.*\.js$$"
+	@./test/run.js
 
 .PHONY: test
 

--- a/lib/stack_trace.js
+++ b/lib/stack_trace.js
@@ -9,12 +9,13 @@ module.exports = StackTrace;
 
 StackTrace.get = function(belowFn) {
   var dummyObject = {};
-  Error.captureStackTrace(dummyObject, belowFn || StackTrace.get);
 
   var v8Handler = Error.prepareStackTrace;
   Error.prepareStackTrace = function(dummyObject, v8StackTrace) {
     return v8StackTrace;
   };
+
+  Error.captureStackTrace(dummyObject, belowFn || StackTrace.get);
 
   var v8StackTrace = dummyObject.stack;
   Error.prepareStackTrace = v8Handler;

--- a/package.json
+++ b/package.json
@@ -11,5 +11,7 @@
     "test": "make test"
   },
   "dependencies": {},
-  "devDependencies": {}
+  "devDependencies": {
+    "far": "~0.0.7"
+  }
 }

--- a/test/run.js
+++ b/test/run.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+var far = require('far').create();
+
+if (process.env.verbose) {
+  far.verbose(process.env.verbose);
+}
+
+far.add(__dirname);
+far.include(/test-.*\.js$/);
+
+far.execute();
+


### PR DESCRIPTION
- Error.prepareStackTrace is not lazy anymore.
- Added test/run.js to make it easier to run tests in different environments.
- Added node-far as devDependency
- Added .gitignore (/node_modules/)

@felixge It will allow node-form-data to pass 0.11.x tests.
